### PR TITLE
fix(regex): match windows line endings aswell

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn handle_supports(pre: &dyn Preprocessor, sub_args: &ArgMatches) -> ! {
 }
 
 lazy_static! {
-    static ref HEADER_RE: Regex = Regex::new(r"(?P<header>---\n((.+\n)+)---)").unwrap();
+    static ref HEADER_RE: Regex = Regex::new(r"(?P<header>---\r?\n((.+\r?\n)+)---)").unwrap();
 }
 
 /// A pre-processor that removes header between ---


### PR DESCRIPTION
Hello @dvogt23,

I noticed that the preprocessor does not work if the markdown file uses windows line endings.
In this PR I fixed this by adding an optional \r before the \n in the regex.

Thank you for this preprocessor it is very useful!


Best regards

Jan