### PR TITLE
Disable default features for mdbook crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,6 @@ description = "mdBook preprocessor for removing yml header"
 [dependencies]
 clap = "3.*"
 lazy_static = "1.*"
-mdbook = "0.4.*"
+mdbook = { version = "0.4.*", default-features = false }
 regex = "1.*"
 serde_json = "1.*"


### PR DESCRIPTION
Thanks for this extension!

Someone building this doesn't need tokio/elasticsearch/etc. for the server in the mdbook dependency, so this PR disables those server features.